### PR TITLE
fixed inconsistency in wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This hook functions similarly to `useState`, with the exception of the the cavea
 import useLocalStorage from '@illinois/react-use-local-storage'
 
 const MyComponent = () => {
-  const [value, setValue] = useLocalStorage('value-key', 0)
+  const [count, setCount] = useLocalStorage('value-key', 0)
   return (
     <>
       <div>Count: {count}</div>


### PR DESCRIPTION
The example had a small error. Instead of `count` and `setCount` the variables were called `value` and `setValue` which didn't match up the rest of the code. 